### PR TITLE
Update IRC metadata to libera.chat

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ WriteMakefile(
         url  => 'https://github.com/mojolicious/mojo-status.git',
         web  => 'https://github.com/mojolicious/mojo-status',
       },
-      x_IRC => {url => 'irc://irc.freenode.net/#mojo', web => 'https://webchat.freenode.net/#mojo'}
+      x_IRC => {url => 'irc://irc.libera.chat/#mojo', web => 'https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo'}
     },
   },
   PREREQ_PM => {Mojolicious => '9.11', 'BSD::Resource' => 0, 'Sereal' => 0, 'File::Map' => 0, 'File::Temp' => '0.2308'},


### PR DESCRIPTION
### Summary
Update #mojo in metadata to libera.chat

### Motivation
The IRC channel is moving

### References
https://github.com/mojolicious/mojo/pull/1788