### PR TITLE
Show Perl version in dashboard

### DIFF
--- a/lib/Mojolicious/Plugin/resources/templates/mojo-status/dashboard.html.ep
+++ b/lib/Mojolicious/Plugin/resources/templates/mojo-status/dashboard.html.ep
@@ -27,6 +27,13 @@
         </tr>
         <tr>
           <th class="fit text-left noleftpad" scope="row">
+            <i class="fas fa-code"></i>
+          </th>
+          <th class="fit text-left noleftpad" scope="row">Perl:</th>
+          <td><%= "$^V, $^O" %></td>
+        </tr>
+        <tr>
+          <th class="fit text-left noleftpad" scope="row">
             <i class="fas fa-microchip"></i>
           </th>
           <th class="fit text-left noleftpad" scope="row">Plugin:</th>
@@ -157,7 +164,7 @@
             <td><%= $row->[8] // '' %></td>
             <td><%= $row->[9] // '' %></td>
             <td class="wrappable"><code><%= $row->[10] // '' %></code></td>
-          </tr> 
+          </tr>
         % }
       </tbody>
     </table>


### PR DESCRIPTION
### Summary
Shows the version of Perl in use by the process

### Motivation
It conveys useful information that should be present in the dashboard since users might have multiple Perls installed.

### References
I had asked in #perl if there was a way to show the current version of Perl with either morbo or with Hypnotoad and it didn't seem like there was a built-in method for this.